### PR TITLE
Remove Option from commit.compare() return type

### DIFF
--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -71,7 +71,8 @@ impl BucketCommand for Commit {
             Ok(Some(previous_commit)) => {
                 // Compare the current commit with the previous commit
                 println!("Previous commit found. Comparing with current commit. ########################################################## ");
-                if let Some(changes) = current_commit.compare(&previous_commit) {
+                let changes = current_commit.compare(&previous_commit);
+                if !changes.is_empty() {
                     // Process the files that have changed
                     println!("Processing files that have changed. ########################################################## ");
                     self.process_files(

--- a/src/data/commit.rs
+++ b/src/data/commit.rs
@@ -87,7 +87,7 @@ impl PartialEq for CommitStatus {
 
 impl Commit {
     #[allow(dead_code)]
-    pub fn compare(&self, other_commit: &Commit) -> Option<Vec<CommittedFile>> {
+    pub fn compare(&self, other_commit: &Commit) -> Vec<CommittedFile> {
         let Commit {
             bucket: _,
             files: _,
@@ -166,7 +166,7 @@ impl Commit {
                     }
                 }
             }
-            Some(status_all_files)
+            status_all_files
         }
     }
 }
@@ -278,8 +278,6 @@ mod tests {
         };
 
         let changes = commit1.compare(&commit2);
-        assert!(changes.is_some());
-        let changes = changes.unwrap();
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].status, CommitStatus::Committed);
     }
@@ -319,8 +317,6 @@ mod tests {
         };
 
         let changes = commit1.compare(&commit2);
-        assert!(changes.is_some());
-        let changes = changes.unwrap();
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].status, CommitStatus::Modified);
     }
@@ -352,8 +348,6 @@ mod tests {
         };
 
         let changes = commit1.compare(&commit2);
-        assert!(changes.is_some());
-        let changes = changes.unwrap();
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].status, CommitStatus::New);
     }
@@ -385,8 +379,6 @@ mod tests {
         };
 
         let changes = commit1.compare(&commit2);
-        assert!(changes.is_some());
-        let changes = changes.unwrap();
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].status, CommitStatus::Deleted);
     }


### PR DESCRIPTION
This pull request fixes #58 by removing the unnecessary Option from the return type of the `commit.compare()` function. The function now directly returns a `Vec<CommittedFile>`, simplifying the handling of changes. This change affects both the implementation and the associated tests, where the `Option` handling has been removed to reflect the updated return type.