### PR TITLE
Clean up compilation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 permissions:
   contents: read
@@ -28,12 +28,12 @@ jobs:
           toolchain: stable
 
       - uses: Swatinem/rust-cache@v2
-            
+
       - name: Build and Test
         run: |
           cargo build --release --all-features
           cargo test --release
-    
+
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: taiki-e/install-action@cargo-nextest
 
@@ -48,6 +48,7 @@ jobs:
 
       - name: Build Debian package
         run: |
+          cargo install cargo-deb
           cargo deb --no-build
 
       - name: Upload Debian package artifacts
@@ -55,7 +56,7 @@ jobs:
         with:
           name: debian
           path: debian/
-          
+
       - name: Create Release (on tag push)
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,12 +1,12 @@
 use crate::errors::BucketError;
-use crate::postgres_db::{DatabaseConfig, init_database};
-use std::path::Path;
+use crate::postgres_db::{init_database, DatabaseConfig};
 use std::fs;
+use std::path::Path;
 
 #[derive(Debug, Clone, Copy)]
 pub enum DatabaseType {
-    Embedded,    // Embedded PostgreSQL
-    External,    // External PostgreSQL server
+    Embedded, // Embedded PostgreSQL
+    External, // External PostgreSQL server
 }
 
 impl DatabaseType {
@@ -31,9 +31,10 @@ impl DatabaseType {
 
 /// Get the database configuration for the repository
 /// Returns an error if no configuration exists - never defaults
+#[allow(dead_code)] // Used for PostgreSQL migration
 pub fn get_database_config(repo_path: &Path) -> Result<DatabaseConfig, BucketError> {
     let config_file = repo_path.join(".buckets").join("db_config.toml");
-    
+
     if config_file.exists() {
         let content = fs::read_to_string(&config_file)?;
         parse_database_config(&content, repo_path)
@@ -44,9 +45,10 @@ pub fn get_database_config(repo_path: &Path) -> Result<DatabaseConfig, BucketErr
 
 /// Get the database configuration with embedded fallback for backwards compatibility
 /// Only use this for commands that can work with embedded by default
+#[allow(dead_code)] // Used for PostgreSQL migration
 pub fn get_database_config_with_fallback(repo_path: &Path) -> Result<DatabaseConfig, BucketError> {
     let config_file = repo_path.join(".buckets").join("db_config.toml");
-    
+
     if config_file.exists() {
         let content = fs::read_to_string(&config_file)?;
         parse_database_config(&content, repo_path)
@@ -60,22 +62,24 @@ pub fn get_database_config_with_fallback(repo_path: &Path) -> Result<DatabaseCon
 }
 
 /// Parse database configuration from TOML string
+#[allow(dead_code)] // Used for PostgreSQL migration
 fn parse_database_config(content: &str, repo_path: &Path) -> Result<DatabaseConfig, BucketError> {
-    let config: toml::Value = content.parse()
+    let config: toml::Value = content
+        .parse()
         .map_err(|e| BucketError::from(format!("Invalid database config: {}", e).as_str()))?;
-    
+
     let db_type = config
         .get("type")
         .and_then(|v| v.as_str())
         .unwrap_or("embedded");
-    
+
     match db_type {
         "embedded" => {
             let port = config
                 .get("port")
                 .and_then(|v| v.as_integer())
                 .map(|p| p as u16);
-            
+
             Ok(DatabaseConfig::Embedded {
                 data_dir: repo_path.join(".buckets").join("postgres"),
                 port,
@@ -87,30 +91,30 @@ fn parse_database_config(content: &str, repo_path: &Path) -> Result<DatabaseConf
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| BucketError::from("Missing 'host' in external database config"))?
                 .to_string();
-            
+
             let port = config
                 .get("port")
                 .and_then(|v| v.as_integer())
                 .map(|p| p as u16)
                 .unwrap_or(5432);
-            
+
             let database = config
                 .get("database")
                 .and_then(|v| v.as_str())
                 .unwrap_or("buckets")
                 .to_string();
-            
+
             let username = config
                 .get("username")
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| BucketError::from("Missing 'username' in external database config"))?
                 .to_string();
-            
+
             let password = config
                 .get("password")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
-            
+
             Ok(DatabaseConfig::External {
                 host,
                 port,
@@ -119,14 +123,16 @@ fn parse_database_config(content: &str, repo_path: &Path) -> Result<DatabaseConf
                 password,
             })
         }
-        _ => Err(BucketError::from(format!("Invalid database type: {}", db_type).as_str()))
+        _ => Err(BucketError::from(
+            format!("Invalid database type: {}", db_type).as_str(),
+        )),
     }
 }
 
 /// Save database configuration to file
 pub fn save_database_config(repo_path: &Path, config: &DatabaseConfig) -> Result<(), BucketError> {
     let config_file = repo_path.join(".buckets").join("db_config.toml");
-    
+
     let toml_content = match config {
         DatabaseConfig::Embedded { port, .. } => {
             let mut content = String::from("type = \"embedded\"\n");
@@ -135,7 +141,13 @@ pub fn save_database_config(repo_path: &Path, config: &DatabaseConfig) -> Result
             }
             content
         }
-        DatabaseConfig::External { host, port, database, username, password } => {
+        DatabaseConfig::External {
+            host,
+            port,
+            database,
+            username,
+            password,
+        } => {
             let mut content = String::from("type = \"external\"\n");
             content.push_str(&format!("host = \"{}\"\n", host));
             content.push_str(&format!("port = {}\n", port));
@@ -147,24 +159,26 @@ pub fn save_database_config(repo_path: &Path, config: &DatabaseConfig) -> Result
             content
         }
     };
-    
+
     fs::write(config_file, toml_content)?;
     Ok(())
 }
 
 /// Synchronous wrapper for initialize_database
+#[allow(dead_code)] // Used for PostgreSQL migration
 pub fn initialize_database(repo_path: &Path, db_type: DatabaseType) -> Result<(), BucketError> {
     // Create a simple runtime for this operation
-    let rt = tokio::runtime::Runtime::new()
-        .map_err(|e| BucketError::from(format!("Failed to create async runtime: {}", e).as_str()))?;
-    
+    let rt = tokio::runtime::Runtime::new().map_err(|e| {
+        BucketError::from(format!("Failed to create async runtime: {}", e).as_str())
+    })?;
+
     rt.block_on(initialize_database_async(repo_path, db_type))
 }
 
 /// Initialize database with explicit external configuration
 pub async fn initialize_database_with_external_config_async(
-    repo_path: &Path, 
-    config: DatabaseConfig
+    repo_path: &Path,
+    config: DatabaseConfig,
 ) -> Result<(), BucketError> {
     // Validate external configuration if needed
     if let DatabaseConfig::External { host, username, .. } = &config {
@@ -172,16 +186,18 @@ pub async fn initialize_database_with_external_config_async(
             return Err(BucketError::from("External database host cannot be empty"));
         }
         if username.is_empty() {
-            return Err(BucketError::from("External database username cannot be empty"));
+            return Err(BucketError::from(
+                "External database username cannot be empty",
+            ));
         }
     }
-    
+
     // Save the config to file for future use
     save_database_config(repo_path.parent().unwrap_or(repo_path), &config)?;
-    
+
     // Initialize the database
     init_database(config.clone()).await?;
-    
+
     // Create a database type marker file for compatibility
     let db_type = match config {
         DatabaseConfig::Embedded { .. } => DatabaseType::Embedded,
@@ -189,12 +205,15 @@ pub async fn initialize_database_with_external_config_async(
     };
     let db_type_file = repo_path.join("database_type");
     fs::write(db_type_file, db_type.as_str())?;
-    
+
     Ok(())
 }
 
 /// Async version of initialize_database
-pub async fn initialize_database_async(repo_path: &Path, db_type: DatabaseType) -> Result<(), BucketError> {
+pub async fn initialize_database_async(
+    repo_path: &Path,
+    db_type: DatabaseType,
+) -> Result<(), BucketError> {
     let config = match db_type {
         DatabaseType::Embedded => DatabaseConfig::Embedded {
             data_dir: repo_path.join("postgres"),
@@ -205,7 +224,7 @@ pub async fn initialize_database_async(repo_path: &Path, db_type: DatabaseType) 
             return Err(BucketError::from("External database type specified but no configuration provided. External databases require explicit configuration with host, username, and other connection details. Use the init command with --external-host, --external-username, etc. options."));
         }
     };
-    
+
     initialize_database_with_external_config_async(repo_path, config).await
 }
 
@@ -213,48 +232,54 @@ pub async fn initialize_database_async(repo_path: &Path, db_type: DatabaseType) 
 mod tests {
     use super::*;
     use tempfile::tempdir;
-    
+
     #[test]
     fn test_get_database_config_fails_without_config() {
         let temp_dir = tempdir().expect("Failed to create temp dir");
         let buckets_dir = temp_dir.path().join(".buckets");
         std::fs::create_dir_all(&buckets_dir).expect("Failed to create .buckets dir");
-        
+
         // Should fail because no config file exists
         let result = get_database_config(&buckets_dir);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("No database configuration found"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("No database configuration found"));
     }
-    
+
     #[test]
     fn test_get_database_config_with_fallback_works() {
         let temp_dir = tempdir().expect("Failed to create temp dir");
         let buckets_dir = temp_dir.path().join(".buckets");
         std::fs::create_dir_all(&buckets_dir).expect("Failed to create .buckets dir");
-        
+
         // Should default to embedded for backwards compatibility
         let result = get_database_config_with_fallback(&buckets_dir);
         assert!(result.is_ok());
-        
+
         let config = result.unwrap();
         match config {
-            crate::postgres_db::DatabaseConfig::Embedded { .. } => {},
+            crate::postgres_db::DatabaseConfig::Embedded { .. } => {}
             _ => panic!("Expected embedded config"),
         }
     }
-    
+
     #[test]
     fn test_initialize_external_database_fails_without_config() {
         let temp_dir = tempdir().expect("Failed to create temp dir");
         let buckets_dir = temp_dir.path().join(".buckets");
         std::fs::create_dir_all(&buckets_dir).expect("Failed to create .buckets dir");
-        
+
         // Should fail because external requires explicit configuration
         let result = initialize_database(&buckets_dir, DatabaseType::External);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("External database type specified but no configuration provided"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("External database type specified but no configuration provided"));
     }
-    
+
     #[test]
     fn test_parse_external_database_config_missing_host() {
         let config_content = r#"
@@ -264,24 +289,27 @@ database = "buckets"
 username = "user"
 "#;
         let temp_dir = tempdir().expect("Failed to create temp dir");
-        
+
         let result = parse_database_config(config_content, temp_dir.path());
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Missing 'host'"));
     }
-    
+
     #[test]
     fn test_parse_external_database_config_missing_username() {
         let config_content = r#"
 type = "external"
-host = "localhost"  
+host = "localhost"
 port = 5432
 database = "buckets"
 "#;
         let temp_dir = tempdir().expect("Failed to create temp dir");
-        
+
         let result = parse_database_config(config_content, temp_dir.path());
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Missing 'username'"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Missing 'username'"));
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,6 +8,7 @@ pub enum BucketError {
     #[error("Database Error: {0}")]
     PostgreSQL(#[from] tokio_postgres::Error),
     #[error("Database Error: {0}")]
+    #[allow(dead_code)] // Used for PostgreSQL migration
     DatabaseError(String),
     #[error("Bucket already exists")]
     BucketAlreadyExists,
@@ -24,6 +25,7 @@ pub enum BucketError {
     #[error("Invalid data {0}")]
     InvalidData(String),
     #[error("Not found {0}")]
+    #[allow(dead_code)] // Used for PostgreSQL migration
     NotFound(String),
     #[error("File not found {0}")]
     FileNotFound(String),
@@ -38,7 +40,6 @@ impl From<&str> for BucketError {
         BucketError::IoError(io::Error::new(io::ErrorKind::Other, error))
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/postgres_db.rs
+++ b/src/postgres_db.rs
@@ -19,6 +19,7 @@ pub enum DatabaseConfig {
         port: Option<u16>,
     },
     /// Connect to an external PostgreSQL server
+    #[allow(dead_code)] // Used for PostgreSQL migration
     External {
         host: String,
         port: u16,
@@ -30,14 +31,13 @@ pub enum DatabaseConfig {
 
 impl DatabaseConfig {
     /// Create config from environment or defaults
+    #[allow(dead_code)] // Used for PostgreSQL migration
     pub fn from_env(repo_path: &Path) -> Self {
         if let Ok(url) = std::env::var("DATABASE_URL") {
             // Parse PostgreSQL connection URL
-            Self::from_url(&url).unwrap_or_else(|_| {
-                Self::Embedded {
-                    data_dir: repo_path.join(".b").join("postgres"),
-                    port: None,
-                }
+            Self::from_url(&url).unwrap_or_else(|_| Self::Embedded {
+                data_dir: repo_path.join(".b").join("postgres"),
+                port: None,
             })
         } else {
             Self::Embedded {
@@ -48,30 +48,34 @@ impl DatabaseConfig {
     }
 
     /// Parse a PostgreSQL connection URL
+    #[allow(dead_code)] // Used for PostgreSQL migration
     pub fn from_url(url: &str) -> Result<Self, BucketError> {
         // Parse postgresql://username:password@host:port/database
-        let url = url.strip_prefix("postgresql://")
+        let url = url
+            .strip_prefix("postgresql://")
             .or_else(|| url.strip_prefix("postgres://"))
             .ok_or_else(|| BucketError::from("Invalid PostgreSQL URL"))?;
-        
-        let (auth, rest) = url.split_once('@')
+
+        let (auth, rest) = url
+            .split_once('@')
             .ok_or_else(|| BucketError::from("Invalid PostgreSQL URL"))?;
-        
+
         let (username, password) = if let Some((u, p)) = auth.split_once(':') {
             (u.to_string(), Some(p.to_string()))
         } else {
             (auth.to_string(), None)
         };
-        
-        let (host_port, database) = rest.split_once('/')
+
+        let (host_port, database) = rest
+            .split_once('/')
             .ok_or_else(|| BucketError::from("Invalid PostgreSQL URL"))?;
-        
+
         let (host, port) = if let Some((h, p)) = host_port.split_once(':') {
             (h.to_string(), p.parse().unwrap_or(5432))
         } else {
             (host_port.to_string(), 5432)
         };
-        
+
         Ok(Self::External {
             host,
             port,
@@ -82,16 +86,20 @@ impl DatabaseConfig {
     }
 
     /// Get connection string for this configuration
+    #[allow(dead_code)] // Used for PostgreSQL migration
     pub fn connection_string(&self) -> String {
         match self {
             Self::Embedded { port, .. } => {
                 let port = port.unwrap_or(5432);
-                format!(
-                    "host=localhost port={} user=postgres dbname=buckets",
-                    port
-                )
+                format!("host=localhost port={} user=postgres dbname=buckets", port)
             }
-            Self::External { host, port, database, username, password } => {
+            Self::External {
+                host,
+                port,
+                database,
+                username,
+                password,
+            } => {
                 let mut conn = format!(
                     "host={} port={} user={} dbname={}",
                     host, port, username, database
@@ -126,64 +134,68 @@ impl DatabaseManager {
     pub async fn initialize(&mut self) -> Result<(), BucketError> {
         // Check if we're in a test environment and should skip database initialization
         if std::env::var("BUCKETS_SKIP_DB_INIT").is_ok() {
-            info!("Skipping database initialization due to BUCKETS_SKIP_DB_INIT environment variable");
+            info!(
+                "Skipping database initialization due to BUCKETS_SKIP_DB_INIT environment variable"
+            );
             return Ok(());
         }
-        
+
         // Start embedded PostgreSQL if needed
         if let DatabaseConfig::Embedded { data_dir, port } = &self.config {
             info!("Starting embedded PostgreSQL...");
-            
+
             // Create data directory if it doesn't exist
-            std::fs::create_dir_all(data_dir)
-                .map_err(|e| BucketError::from(format!("Failed to create data directory: {}", e).as_str()))?;
-            
+            std::fs::create_dir_all(data_dir).map_err(|e| {
+                BucketError::from(format!("Failed to create data directory: {}", e).as_str())
+            })?;
+
             let mut settings = Settings::default();
-            settings.version = VersionReq::parse(">=13.0.0")
-                .map_err(|e| BucketError::from(format!("Invalid version requirement: {}", e).as_str()))?;
+            settings.version = VersionReq::parse(">=13.0.0").map_err(|e| {
+                BucketError::from(format!("Invalid version requirement: {}", e).as_str())
+            })?;
             settings.installation_dir = data_dir.join("install");
             settings.data_dir = data_dir.join("data");
             settings.port = port.unwrap_or(0); // 0 means auto-select port
             settings.temporary = false;
             settings.password_file = data_dir.join(".pgpass");
-            
+
             let mut pg = PostgreSQL::new(settings);
-            
+
             // Install PostgreSQL if not already installed
             if !pg.settings().installation_dir.exists() {
                 info!("Installing PostgreSQL...");
-                pg.setup()
-                    .await
-                    .map_err(|e| BucketError::from(format!("Failed to install PostgreSQL: {}", e).as_str()))?;
+                pg.setup().await.map_err(|e| {
+                    BucketError::from(format!("Failed to install PostgreSQL: {}", e).as_str())
+                })?;
             }
-            
+
             // Start PostgreSQL
-            pg.start()
-                .await
-                .map_err(|e| BucketError::from(format!("Failed to start PostgreSQL: {}", e).as_str()))?;
-            
+            pg.start().await.map_err(|e| {
+                BucketError::from(format!("Failed to start PostgreSQL: {}", e).as_str())
+            })?;
+
             // Update config with actual port
             if let DatabaseConfig::Embedded { port: cfg_port, .. } = &mut self.config {
                 *cfg_port = Some(pg.settings().port);
             }
-            
+
             info!("PostgreSQL started on port {}", pg.settings().port);
             self.embedded_pg = Some(pg);
         }
-        
+
         // Create connection pool
         self.create_pool().await?;
-        
+
         // Run migrations
         self.run_migrations().await?;
-        
+
         Ok(())
     }
 
     /// Create connection pool
     async fn create_pool(&mut self) -> Result<(), BucketError> {
         let mut cfg = Config::new();
-        
+
         match &self.config {
             DatabaseConfig::Embedded { port, .. } => {
                 cfg.host = Some("localhost".to_string());
@@ -191,7 +203,13 @@ impl DatabaseManager {
                 cfg.user = Some("postgres".to_string());
                 cfg.dbname = Some("buckets".to_string());
             }
-            DatabaseConfig::External { host, port, database, username, password } => {
+            DatabaseConfig::External {
+                host,
+                port,
+                database,
+                username,
+                password,
+            } => {
                 cfg.host = Some(host.clone());
                 cfg.port = Some(*port);
                 cfg.user = Some(username.clone());
@@ -199,45 +217,55 @@ impl DatabaseManager {
                 cfg.dbname = Some(database.clone());
             }
         }
-        
+
         cfg.connect_timeout = Some(Duration::from_secs(10));
-        
-        let pool = cfg.create_pool(Some(Runtime::Tokio1), NoTls)
-            .map_err(|e| BucketError::from(format!("Failed to create connection pool: {}", e).as_str()))?;
-        
+
+        let pool = cfg.create_pool(Some(Runtime::Tokio1), NoTls).map_err(|e| {
+            BucketError::from(format!("Failed to create connection pool: {}", e).as_str())
+        })?;
+
         // Test connection
-        let _ = pool.get().await
-            .map_err(|e| BucketError::from(format!("Failed to connect to database: {}", e).as_str()))?;
-        
+        let _ = pool.get().await.map_err(|e| {
+            BucketError::from(format!("Failed to connect to database: {}", e).as_str())
+        })?;
+
         self.pool = Some(pool);
         Ok(())
     }
 
     /// Run database migrations
     async fn run_migrations(&self) -> Result<(), BucketError> {
-        let pool = self.pool.as_ref()
+        let pool = self
+            .pool
+            .as_ref()
             .ok_or_else(|| BucketError::from("No connection pool available"))?;
-        
-        let mut client = pool.get().await
-            .map_err(|e| BucketError::from(format!("Failed to get database connection: {}", e).as_str()))?;
-        
+
+        let mut client = pool.get().await.map_err(|e| {
+            BucketError::from(format!("Failed to get database connection: {}", e).as_str())
+        })?;
+
         let runner = migrations::runner();
-        
+
         // Run migrations
-        runner.run_async(&mut **client).await
+        runner
+            .run_async(&mut **client)
+            .await
             .map_err(|e| BucketError::from(format!("Failed to run migrations: {}", e).as_str()))?;
-        
+
         info!("Database migrations completed");
         Ok(())
     }
 
     /// Get a database connection from the pool
     pub async fn get_connection(&self) -> Result<deadpool_postgres::Object, BucketError> {
-        let pool = self.pool.as_ref()
+        let pool = self
+            .pool
+            .as_ref()
             .ok_or_else(|| BucketError::from("Database not initialized"))?;
-        
-        pool.get().await
-            .map_err(|e| BucketError::from(format!("Failed to get database connection: {}", e).as_str()))
+
+        pool.get().await.map_err(|e| {
+            BucketError::from(format!("Failed to get database connection: {}", e).as_str())
+        })
     }
 
     /// Execute a query that returns no results
@@ -247,7 +275,9 @@ impl DatabaseManager {
         params: &[&(dyn tokio_postgres::types::ToSql + Sync)],
     ) -> Result<u64, BucketError> {
         let client = self.get_connection().await?;
-        client.execute(query, params).await
+        client
+            .execute(query, params)
+            .await
             .map_err(|e| BucketError::from(format!("Query failed: {}", e).as_str()))
     }
 
@@ -258,38 +288,44 @@ impl DatabaseManager {
         params: &[&(dyn tokio_postgres::types::ToSql + Sync)],
     ) -> Result<Vec<tokio_postgres::Row>, BucketError> {
         let client = self.get_connection().await?;
-        client.query(query, params).await
+        client
+            .query(query, params)
+            .await
             .map_err(|e| BucketError::from(format!("Query failed: {}", e).as_str()))
     }
 
     /// Shutdown the database (for embedded PostgreSQL)
+    #[allow(dead_code)] // Used for PostgreSQL migration
     pub async fn shutdown(&mut self) -> Result<(), BucketError> {
         if let Some(pg) = self.embedded_pg.take() {
             info!("Stopping embedded PostgreSQL...");
-            pg.stop()
-                .await
-                .map_err(|e| BucketError::from(format!("Failed to stop PostgreSQL: {}", e).as_str()))?;
+            pg.stop().await.map_err(|e| {
+                BucketError::from(format!("Failed to stop PostgreSQL: {}", e).as_str())
+            })?;
         }
         Ok(())
     }
 }
 
 // Global database manager instance
-static DATABASE: once_cell::sync::OnceCell<tokio::sync::Mutex<DatabaseManager>> = once_cell::sync::OnceCell::new();
+static DATABASE: once_cell::sync::OnceCell<tokio::sync::Mutex<DatabaseManager>> =
+    once_cell::sync::OnceCell::new();
 
 /// Initialize the global database
 pub async fn init_database(config: DatabaseConfig) -> Result<(), BucketError> {
     let mut manager = DatabaseManager::new(config);
     manager.initialize().await?;
-    
-    DATABASE.set(tokio::sync::Mutex::new(manager))
+
+    DATABASE
+        .set(tokio::sync::Mutex::new(manager))
         .map_err(|_| BucketError::from("Database already initialized"))?;
-    
+
     Ok(())
 }
 
 /// Get the global database manager
-pub async fn get_database() -> Result<tokio::sync::MutexGuard<'static, DatabaseManager>, BucketError> {
+pub async fn get_database() -> Result<tokio::sync::MutexGuard<'static, DatabaseManager>, BucketError>
+{
     let db = DATABASE
         .get()
         .ok_or_else(|| BucketError::from("Database not initialized"))?;
@@ -297,6 +333,7 @@ pub async fn get_database() -> Result<tokio::sync::MutexGuard<'static, DatabaseM
 }
 
 /// Execute a database operation with the global database
+#[allow(dead_code)] // Used for PostgreSQL migration
 pub async fn with_database<F, T>(f: F) -> Result<T, BucketError>
 where
     F: FnOnce(&DatabaseManager) -> T,

--- a/src/utils/compression.rs
+++ b/src/utils/compression.rs
@@ -1,7 +1,7 @@
 use std::{
     fs::File,
     io::{self},
-    path::{Path, PathBuf},
+    path::Path,
 };
 
 use zstd::stream::{copy_decode, copy_encode};
@@ -13,12 +13,12 @@ pub const DEFAULT_COMPRESSION_LEVEL: i32 = 3;
 pub const MAX_COMPRESSION_LEVEL: i32 = 22;
 
 /// Compress a file using zstd and store it at the specified path
-/// 
+///
 /// # Arguments
 /// * `input_path` - Path to the input file to compress
 /// * `output_path` - Path where the compressed file will be stored
 /// * `compression_level` - Compression level (0 for default, 1-22 for specific levels)
-/// 
+///
 /// # Returns
 /// * `Ok(())` on success
 /// * `Err(io::Error)` on failure with descriptive error message
@@ -33,8 +33,10 @@ pub fn compress_file(
     } else if compression_level < 1 || compression_level > MAX_COMPRESSION_LEVEL {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            format!("Invalid compression level: {}. Must be 0 (default) or 1-{}", 
-                    compression_level, MAX_COMPRESSION_LEVEL),
+            format!(
+                "Invalid compression level: {}. Must be 0 (default) or 1-{}",
+                compression_level, MAX_COMPRESSION_LEVEL
+            ),
         ));
     } else {
         compression_level
@@ -43,24 +45,36 @@ pub fn compress_file(
     let input_file = File::open(input_path).map_err(|e| {
         io::Error::new(
             e.kind(),
-            format!("Failed to open input file '{}': {}", input_path.display(), e),
+            format!(
+                "Failed to open input file '{}': {}",
+                input_path.display(),
+                e
+            ),
         )
     })?;
-    
+
     // Create parent directories if they don't exist
     if let Some(parent) = output_path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| {
             io::Error::new(
                 e.kind(),
-                format!("Failed to create output directory '{}': {}", parent.display(), e),
+                format!(
+                    "Failed to create output directory '{}': {}",
+                    parent.display(),
+                    e
+                ),
             )
         })?;
     }
-    
+
     let mut output_file = File::create(output_path).map_err(|e| {
         io::Error::new(
             e.kind(),
-            format!("Failed to create output file '{}': {}", output_path.display(), e),
+            format!(
+                "Failed to create output file '{}': {}",
+                output_path.display(),
+                e
+            ),
         )
     })?;
 
@@ -80,11 +94,11 @@ pub fn compress_file(
 }
 
 /// Decompress a zstd-compressed file and restore it to the specified path
-/// 
+///
 /// # Arguments
 /// * `input_path` - Path to the compressed file
 /// * `output_path` - Path where the decompressed file will be restored
-/// 
+///
 /// # Returns
 /// * `Ok(())` on success
 /// * `Err(io::Error)` on failure with descriptive error message
@@ -92,27 +106,39 @@ pub fn decompress_file(input_path: &Path, output_path: &Path) -> io::Result<()> 
     let input_file = File::open(input_path).map_err(|e| {
         io::Error::new(
             e.kind(),
-            format!("Failed to open compressed file '{}': {}", input_path.display(), e),
+            format!(
+                "Failed to open compressed file '{}': {}",
+                input_path.display(),
+                e
+            ),
         )
     })?;
-    
+
     // Create parent directories if they don't exist
     if let Some(parent) = output_path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| {
             io::Error::new(
                 e.kind(),
-                format!("Failed to create output directory '{}': {}", parent.display(), e),
+                format!(
+                    "Failed to create output directory '{}': {}",
+                    parent.display(),
+                    e
+                ),
             )
         })?;
     }
-    
+
     let output_file = File::create(output_path).map_err(|e| {
         io::Error::new(
             e.kind(),
-            format!("Failed to create output file '{}': {}", output_path.display(), e),
+            format!(
+                "Failed to create output file '{}': {}",
+                output_path.display(),
+                e
+            ),
         )
     })?;
-    
+
     copy_decode(input_file, output_file).map_err(|e| {
         io::Error::new(
             io::ErrorKind::InvalidData,
@@ -124,26 +150,8 @@ pub fn decompress_file(input_path: &Path, output_path: &Path) -> io::Result<()> 
             ),
         )
     })?;
-    
+
     Ok(())
-}
-
-/// Legacy function for backward compatibility
-/// Use `compress_file` instead
-#[deprecated(since = "0.1.6", note = "Use `compress_file` instead")]
-pub fn compress_and_store_file(
-    input_path: &PathBuf,
-    output_path: &PathBuf,
-    compression_level: i32,
-) -> io::Result<()> {
-    compress_file(input_path, output_path, compression_level)
-}
-
-/// Legacy function for backward compatibility
-/// Use `decompress_file` instead
-#[deprecated(since = "0.1.6", note = "Use `decompress_file` instead")]
-pub fn restore_file(input_path: &PathBuf, output_path: &PathBuf) -> io::Result<()> {
-    decompress_file(input_path, output_path)
 }
 
 #[cfg(test)]
@@ -210,7 +218,8 @@ mod tests {
         fs::remove_file(&restored_file_path).expect("Failed to remove original file");
 
         // Restore the file
-        decompress_file(&compressed_file_path, &restored_file_path).expect("Failed to restore file");
+        decompress_file(&compressed_file_path, &restored_file_path)
+            .expect("Failed to restore file");
         log::info!("File restored successfully");
 
         // Check if the restored file exists and contains the expected content
@@ -233,8 +242,7 @@ mod tests {
         file.write_all(&buffer).expect("Failed to write test data");
 
         // Compress the file
-        compress_file(&input_path, &output_path, 3)
-            .expect("Failed to compress large file");
+        compress_file(&input_path, &output_path, 3).expect("Failed to compress large file");
 
         // Check if the compressed file exists
         assert!(output_path.exists());
@@ -265,8 +273,7 @@ mod tests {
         file.write_all(&buffer).expect("Failed to write test data");
 
         // Compress the file
-        compress_file(&input_path, &output_path, 3)
-            .expect("Failed to compress large file");
+        compress_file(&input_path, &output_path, 3).expect("Failed to compress large file");
 
         // Restore the file
         decompress_file(&output_path, &result_path).expect("Failed to restore large file");
@@ -301,10 +308,16 @@ mod tests {
 
         // Test compression to non-existent directory (should succeed because we auto-create directories)
         let result = compress_file(&input_path, &invalid_output_path, 3);
-        assert!(result.is_ok(), "Compression should succeed because parent directories are auto-created");
-        
+        assert!(
+            result.is_ok(),
+            "Compression should succeed because parent directories are auto-created"
+        );
+
         // Verify the file was created
-        assert!(invalid_output_path.exists(), "Output file should exist after compression");
+        assert!(
+            invalid_output_path.exists(),
+            "Output file should exist after compression"
+        );
     }
 
     #[test]
@@ -401,8 +414,7 @@ mod tests {
         File::create(&input_path).expect("Failed to create empty file");
 
         // Compress empty file
-        compress_file(&input_path, &output_path, 3)
-            .expect("Failed to compress empty file");
+        compress_file(&input_path, &output_path, 3).expect("Failed to compress empty file");
         assert!(output_path.exists());
 
         // Restore empty file
@@ -476,7 +488,8 @@ mod tests {
             assert!(compressed_path.exists());
 
             // Restore
-            decompress_file(&compressed_path, &restored_path).expect("Failed to restore test content");
+            decompress_file(&compressed_path, &restored_path)
+                .expect("Failed to restore test content");
             assert!(restored_path.exists());
 
             // Verify content matches
@@ -493,13 +506,21 @@ mod tests {
     #[test]
     fn test_binary_file_roundtrip() {
         let dir = tempdir().expect("Failed to create temp dir");
-        
+
         // Test various binary patterns
         let test_cases = vec![
             ("zeros", vec![0u8; 1000]),
             ("ones", vec![255u8; 1000]),
-            ("alternating", (0..1000).map(|i| if i % 2 == 0 { 0xAA } else { 0x55 }).collect()),
-            ("random_pattern", (0..1000).map(|i| (i * 17 + 42) as u8).collect()),
+            (
+                "alternating",
+                (0..1000)
+                    .map(|i| if i % 2 == 0 { 0xAA } else { 0x55 })
+                    .collect(),
+            ),
+            (
+                "random_pattern",
+                (0..1000).map(|i| (i * 17 + 42) as u8).collect(),
+            ),
             ("all_bytes", (0u8..=255u8).cycle().take(2000).collect()),
             ("sparse", {
                 let mut data = vec![0u8; 1000];
@@ -529,11 +550,15 @@ mod tests {
             assert!(restored_path.exists());
 
             // Verify binary content matches exactly
-            let restored_data = fs::read(&restored_path).expect("Failed to read restored binary data");
+            let restored_data =
+                fs::read(&restored_path).expect("Failed to read restored binary data");
             assert_eq!(
-                restored_data, binary_data,
+                restored_data,
+                binary_data,
                 "Binary data mismatch for test case: {} (original len: {}, restored len: {})",
-                name, binary_data.len(), restored_data.len()
+                name,
+                binary_data.len(),
+                restored_data.len()
             );
         }
     }
@@ -541,10 +566,10 @@ mod tests {
     #[test]
     fn test_large_binary_file_roundtrip() {
         let dir = tempdir().expect("Failed to create temp dir");
-        
+
         // Generate a large binary file with patterns
         let mut large_binary = Vec::with_capacity(1024 * 1024); // 1MB
-        
+
         // Fill with structured binary data
         for chunk in 0..(1024 * 1024 / 1024) {
             for byte_idx in 0..1024 {
@@ -553,7 +578,7 @@ mod tests {
                 large_binary.push(pattern_byte);
             }
         }
-        
+
         let input_path = dir.path().join("large_binary.bin");
         let compressed_path = dir.path().join("large_binary.zst");
         let restored_path = dir.path().join("large_binary_restored.bin");
@@ -570,11 +595,15 @@ mod tests {
         let original_size = fs::metadata(&input_path).unwrap().len();
         let compressed_size = fs::metadata(&compressed_path).unwrap().len();
         let compression_ratio = compressed_size as f64 / original_size as f64;
-        
+
         // Pattern-based data should compress well, expect at least 50% compression
-        assert!(compression_ratio < 0.8, 
-                "Compression ratio too low: {:.2}% (compressed: {} bytes, original: {} bytes)",
-                compression_ratio * 100.0, compressed_size, original_size);
+        assert!(
+            compression_ratio < 0.8,
+            "Compression ratio too low: {:.2}% (compressed: {} bytes, original: {} bytes)",
+            compression_ratio * 100.0,
+            compressed_size,
+            original_size
+        );
 
         // Decompress
         decompress_file(&compressed_path, &restored_path)
@@ -582,44 +611,52 @@ mod tests {
         assert!(restored_path.exists());
 
         // Verify exact binary match
-        let restored_data = fs::read(&restored_path).expect("Failed to read restored large binary file");
-        assert_eq!(restored_data.len(), large_binary.len(), "Size mismatch after decompression");
-        assert_eq!(restored_data, large_binary, "Large binary data corrupted during compression round-trip");
+        let restored_data =
+            fs::read(&restored_path).expect("Failed to read restored large binary file");
+        assert_eq!(
+            restored_data.len(),
+            large_binary.len(),
+            "Size mismatch after decompression"
+        );
+        assert_eq!(
+            restored_data, large_binary,
+            "Large binary data corrupted during compression round-trip"
+        );
     }
 
     #[test]
     fn test_executable_binary_roundtrip() {
         let dir = tempdir().expect("Failed to create temp dir");
-        
+
         // Simulate executable binary with header, code sections, and data
         let mut executable_data = Vec::new();
-        
+
         // ELF-like header (fake)
         executable_data.extend_from_slice(b"\x7fELF\x02\x01\x01\x00");
         executable_data.extend_from_slice(&[0u8; 8]); // padding
-        
+
         // Machine code patterns (x86_64-like)
         let code_patterns = [
-            &[0x48, 0x89, 0xe5][..], // mov %rsp, %rbp
+            &[0x48, 0x89, 0xe5][..],             // mov %rsp, %rbp
             &[0xb8, 0x00, 0x00, 0x00, 0x00][..], // mov $0, %eax
-            &[0x5d][..], // pop %rbp
-            &[0xc3][..], // ret
+            &[0x5d][..],                         // pop %rbp
+            &[0xc3][..],                         // ret
         ];
-        
+
         for _ in 0..100 {
             for pattern in &code_patterns {
                 executable_data.extend_from_slice(pattern);
             }
         }
-        
+
         // String table
         executable_data.extend_from_slice(b"\0main\0printf\0exit\0");
-        
+
         // Padding/alignment
         while executable_data.len() % 16 != 0 {
             executable_data.push(0);
         }
-        
+
         let input_path = dir.path().join("fake_executable.bin");
         let compressed_path = dir.path().join("fake_executable.zst");
         let restored_path = dir.path().join("fake_executable_restored.bin");
@@ -639,21 +676,23 @@ mod tests {
 
         // Verify exact match (critical for executables)
         let restored_data = fs::read(&restored_path).expect("Failed to read restored executable");
-        assert_eq!(restored_data, executable_data, 
-                   "Executable binary corrupted during compression - this would break the program!");
+        assert_eq!(
+            restored_data, executable_data,
+            "Executable binary corrupted during compression - this would break the program!"
+        );
     }
 
     #[test]
     fn test_multimedia_binary_roundtrip() {
         let dir = tempdir().expect("Failed to create temp dir");
-        
+
         // Simulate multimedia file patterns (like JPEG, PNG headers and data)
         let mut multimedia_data = Vec::new();
-        
+
         // JPEG-like header
         multimedia_data.extend_from_slice(&[0xFF, 0xD8, 0xFF, 0xE0]);
         multimedia_data.extend_from_slice(b"JFIF");
-        
+
         // Random image-like data with some structure
         for y in 0..100 {
             for x in 0..100 {
@@ -664,10 +703,10 @@ mod tests {
                 multimedia_data.extend_from_slice(&[r, g, b]);
             }
         }
-        
+
         // JPEG-like footer
         multimedia_data.extend_from_slice(&[0xFF, 0xD9]);
-        
+
         let input_path = dir.path().join("multimedia.bin");
         let compressed_path = dir.path().join("multimedia.zst");
         let restored_path = dir.path().join("multimedia_restored.bin");
@@ -687,12 +726,22 @@ mod tests {
 
         // Verify exact match
         let restored_data = fs::read(&restored_path).expect("Failed to read restored multimedia");
-        assert_eq!(restored_data, multimedia_data, 
-                   "Multimedia binary corrupted during compression");
-        
+        assert_eq!(
+            restored_data, multimedia_data,
+            "Multimedia binary corrupted during compression"
+        );
+
         // Verify header and footer integrity specifically
-        assert_eq!(&restored_data[0..4], &[0xFF, 0xD8, 0xFF, 0xE0], "JPEG header corrupted");
-        assert_eq!(&restored_data[restored_data.len()-2..], &[0xFF, 0xD9], "JPEG footer corrupted");
+        assert_eq!(
+            &restored_data[0..4],
+            &[0xFF, 0xD8, 0xFF, 0xE0],
+            "JPEG header corrupted"
+        );
+        assert_eq!(
+            &restored_data[restored_data.len() - 2..],
+            &[0xFF, 0xD9],
+            "JPEG footer corrupted"
+        );
     }
 
     #[test]
@@ -700,27 +749,35 @@ mod tests {
         let dir = tempdir().expect("Failed to create temp dir");
         let input_path = dir.path().join("test.txt");
         let output_path = dir.path().join("test.zst");
-        
+
         fs::write(&input_path, "test content").expect("Failed to write test file");
-        
+
         // Test invalid compression levels
         let invalid_levels = [-1, 23, 100];
         for level in invalid_levels {
             let result = compress_file(&input_path, &output_path, level);
-            assert!(result.is_err(), "Should fail for invalid compression level: {}", level);
-            
+            assert!(
+                result.is_err(),
+                "Should fail for invalid compression level: {}",
+                level
+            );
+
             if let Err(e) = result {
                 assert_eq!(e.kind(), io::ErrorKind::InvalidInput);
                 assert!(e.to_string().contains("Invalid compression level"));
             }
         }
-        
+
         // Test valid compression levels
         let valid_levels = [0, 1, 3, 9, 22];
         for level in valid_levels {
             let output_path = dir.path().join(format!("test_{}.zst", level));
             let result = compress_file(&input_path, &output_path, level);
-            assert!(result.is_ok(), "Should succeed for valid compression level: {}", level);
+            assert!(
+                result.is_ok(),
+                "Should succeed for valid compression level: {}",
+                level
+            );
             assert!(output_path.exists());
         }
     }
@@ -729,22 +786,22 @@ mod tests {
     fn test_new_functions_with_path_types() {
         let dir = tempdir().expect("Failed to create temp dir");
         let content = b"Test content for new functions";
-        
+
         // Test with &Path (preferred)
         let input_path = dir.path().join("input.txt");
         let compressed_path = dir.path().join("compressed.zst");
         let restored_path = dir.path().join("restored.txt");
-        
+
         fs::write(&input_path, content).expect("Failed to write test file");
-        
+
         // Test compress_file with &Path
         compress_file(&input_path, &compressed_path, 0).expect("compress_file failed");
         assert!(compressed_path.exists());
-        
+
         // Test decompress_file with &Path
         decompress_file(&compressed_path, &restored_path).expect("decompress_file failed");
         assert!(restored_path.exists());
-        
+
         let restored_content = fs::read(&restored_path).expect("Failed to read restored file");
         assert_eq!(restored_content, content);
     }

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -3,7 +3,7 @@ use blake3::{Hash, Hasher};
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::{env, fs, io};
+use std::{fs, io};
 use walkdir::{DirEntry, WalkDir};
 
 #[allow(dead_code)]
@@ -90,26 +90,10 @@ pub fn find_bucket_repo(dir_path: &Path) -> Option<PathBuf> {
     }
 }
 
-/// Validates that the current directory is inside a valid repository.
-/// This function checks for the presence of a `.buckets` directory in the parent hierarchy.
-pub fn validate_repo() -> Result<(), BucketError> {
-    let current_dir = env::current_dir()?;
-
-    let _buckets_path = match find_directory_in_parents(&current_dir, ".buckets") {
-        Some(path) => path,
-        None => return Err(BucketError::NotInRepo),
-    };
-
-    // For now, just check if we're in a valid repo
-    // The actual database connections are handled by the PostgreSQL module
-    Ok(())
-}
-
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs::create_dir_all;
+    use std::{env, fs::create_dir_all};
     use tempfile::tempdir;
 
     #[test]
@@ -300,8 +284,6 @@ mod tests {
         assert_eq!(result, None);
     }
 
-
-
     #[test]
     fn test_hash_file_large_file() -> io::Result<()> {
         let temp_dir = tempdir().expect("failed to create temp dir");
@@ -481,7 +463,4 @@ mod tests {
 
         Ok(())
     }
-
-
 }
-


### PR DESCRIPTION
- Remove deprecated utility functions (compress_and_store_file, restore_file, validate_repo)
- Add #[allow(dead_code)] annotations to PostgreSQL migration functions
- Fix unused import warnings
- Achieve clean build with 0 warnings while preserving migration code