### PR TITLE
Bootstrap repository database connections

### DIFF
--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,0 +1,156 @@
+use std::fs;
+use std::io::{Error, ErrorKind};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use once_cell::sync::Lazy;
+use serde::Deserialize;
+
+use crate::errors::BucketError;
+use crate::postgres_db::{init_database, DatabaseConfig};
+use crate::utils::config::GlobalConfig;
+use crate::utils::utils::find_bucket_repo;
+use crate::CURRENT_DIR;
+
+static BOOTSTRAPPED: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
+
+#[derive(Debug)]
+enum ConnectionSource {
+    Repository(PathBuf),
+    Global(PathBuf),
+}
+
+impl ConnectionSource {
+    fn path(&self) -> &Path {
+        match self {
+            ConnectionSource::Repository(path) | ConnectionSource::Global(path) => path,
+        }
+    }
+
+    fn description(&self) -> &'static str {
+        match self {
+            ConnectionSource::Repository(_) => "repository configuration",
+            ConnectionSource::Global(_) => "global configuration",
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct RepositoryConfigSnapshot {
+    #[serde(default)]
+    postgresql_connection: Option<String>,
+}
+
+pub fn bootstrap_database() -> Result<(), BucketError> {
+    if BOOTSTRAPPED.load(Ordering::SeqCst) {
+        return Ok(());
+    }
+
+    match perform_bootstrap() {
+        Ok(()) => {
+            BOOTSTRAPPED.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+        Err(err) => {
+            // If the database is already initialized we can treat this as success.
+            if err.to_string().contains("Database already initialized") {
+                BOOTSTRAPPED.store(true, Ordering::SeqCst);
+                Ok(())
+            } else {
+                Err(err)
+            }
+        }
+    }
+}
+
+fn perform_bootstrap() -> Result<(), BucketError> {
+    let current_dir = CURRENT_DIR.with(|dir| dir.clone());
+    let buckets_dir = find_bucket_repo(&current_dir).ok_or(BucketError::NotInRepo)?;
+
+    let repo_source = buckets_dir.join("config");
+    let (connection_string, source) = match read_repository_connection(&repo_source)? {
+        Some(connection) => (connection, ConnectionSource::Repository(repo_source)),
+        None => {
+            let global_path = GlobalConfig::config_path()?;
+            let global_config = GlobalConfig::load().map_err(|err| {
+                BucketError::IoError(Error::new(
+                    ErrorKind::InvalidData,
+                    format!(
+                        "Failed to read global configuration at {}: {}",
+                        global_path.display(),
+                        err
+                    ),
+                ))
+            })?;
+
+            if let Some(connection) = global_config.postgresql_connection {
+                (connection, ConnectionSource::Global(global_path))
+            } else {
+                return Err(BucketError::IoError(Error::new(
+                    ErrorKind::NotFound,
+                    format!(
+                        "No PostgreSQL connection found in {} or {}. Run 'buckets setup' or update the repository configuration.",
+                        repo_source.display(),
+                        global_path.display()
+                    ),
+                )));
+            }
+        }
+    };
+
+    let config = DatabaseConfig::from_url(&connection_string).map_err(|err| {
+        BucketError::IoError(Error::new(
+            ErrorKind::InvalidData,
+            format!(
+                "Invalid PostgreSQL connection string in {}: {}",
+                source.path().display(),
+                err
+            ),
+        ))
+    })?;
+
+    let runtime = tokio::runtime::Runtime::new().map_err(|err| {
+        BucketError::IoError(Error::new(
+            ErrorKind::Other,
+            format!(
+                "Failed to create async runtime for database bootstrap: {}",
+                err
+            ),
+        ))
+    })?;
+
+    let init_result = runtime.block_on(async { init_database(config).await });
+
+    match init_result {
+        Ok(()) => Ok(()),
+        Err(err) => Err(BucketError::IoError(Error::new(
+            ErrorKind::Other,
+            format!(
+                "Failed to initialize PostgreSQL using the {} at {}: {}",
+                source.description(),
+                source.path().display(),
+                err
+            ),
+        ))),
+    }
+}
+
+fn read_repository_connection(config_path: &Path) -> Result<Option<String>, BucketError> {
+    if !config_path.is_file() {
+        return Ok(None);
+    }
+
+    let contents = fs::read_to_string(config_path)?;
+    let snapshot: RepositoryConfigSnapshot = toml::from_str(&contents).map_err(|err| {
+        BucketError::IoError(Error::new(
+            ErrorKind::InvalidData,
+            format!(
+                "Failed to parse repository configuration at {}: {}",
+                config_path.display(),
+                err
+            ),
+        ))
+    })?;
+
+    Ok(snapshot.postgresql_connection)
+}

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -53,7 +53,7 @@ pub fn bootstrap_database() -> Result<(), BucketError> {
         }
         Err(err) => {
             // If the database is already initialized we can treat this as success.
-            if err.to_string().contains("Database already initialized") {
+            if matches!(err, BucketError::DatabaseAlreadyInitialized) {
                 BOOTSTRAPPED.store(true, Ordering::SeqCst);
                 Ok(())
             } else {

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -20,6 +20,20 @@ impl BucketCommand for Setup {
     }
 
     fn execute(&self) -> Result<(), BucketError> {
+        if self.args.shared.json {
+            if self.args.test_connection {
+                return Err(BucketError::InvalidData(
+                    "--json cannot be combined with --test-connection".to_string(),
+                ));
+            }
+
+            let config = GlobalConfig::load().unwrap_or_default();
+            let json = serde_json::to_string_pretty(&config)
+                .map_err(|e| BucketError::InvalidData(e.to_string()))?;
+            println!("{}", json);
+            return Ok(());
+        }
+
         println!("Buckets Global Configuration Setup");
         println!("=================================");
         println!();

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 mod args;
+mod bootstrap;
 mod commands;
 mod config;
 mod data;
@@ -71,6 +72,10 @@ fn main() -> ExitCode {
 }
 
 fn dispatch() -> Result<(), BucketError> {
+    if command_requires_repository(&ARGS.command) {
+        bootstrap::bootstrap_database()?;
+    }
+
     match &ARGS.command {
         // Commands that modify the repository
         Command::Init(command) => commands::init::Init::new(command).execute()?,
@@ -96,4 +101,12 @@ fn dispatch() -> Result<(), BucketError> {
     }
 
     Ok(())
+}
+
+fn command_requires_repository(command: &Command) -> bool {
+    match command {
+        Command::Init(_) | Command::Setup(_) => false,
+        Command::Doctor(args) => args.use_repo,
+        _ => true,
+    }
 }

--- a/tests/test_cli_bootstrap.rs
+++ b/tests/test_cli_bootstrap.rs
@@ -1,0 +1,136 @@
+mod common;
+
+#[cfg(test)]
+mod tests {
+    use assert_cmd::Command;
+    use predicates::prelude::*;
+    use serial_test::serial;
+    use std::fs;
+    use std::io::Write;
+    use std::panic;
+    use uuid::Uuid;
+
+    use crate::common::tests::{get_test_dir, RepoFixture, TestDatabase};
+
+    #[test]
+    #[serial]
+    fn bootstrap_uses_repository_configuration() {
+        let Some(fixture) = repo_fixture_or_skip() else {
+            return;
+        };
+
+        let previous_database_url = std::env::var("DATABASE_URL").ok();
+        std::env::remove_var("DATABASE_URL");
+
+        let mut cmd = Command::cargo_bin("buckets").expect("failed to run command");
+        cmd.current_dir(fixture.repo_dir.as_path())
+            .arg("status")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Repository config"));
+
+        restore_database_url(previous_database_url);
+    }
+
+    #[test]
+    #[serial]
+    fn bootstrap_errors_when_connection_missing() {
+        let temp_dir = get_test_dir();
+        let repo_dir = temp_dir.join(format!("bootstrap_missing_{}", Uuid::new_v4().simple()));
+        let buckets_dir = repo_dir.join(".buckets");
+        fs::create_dir_all(&buckets_dir).expect("failed to create .buckets");
+        fs::write(buckets_dir.join("database_type"), "PostgreSQL")
+            .expect("failed to write database_type");
+
+        let mut config_file =
+            fs::File::create(buckets_dir.join("config")).expect("failed to create config file");
+        writeln!(
+            config_file,
+            "ntp_server = \"pool.ntp.org\"\nip_check = \"8.8.8.8\"\nurl_check = \"api.ipify.org\""
+        )
+        .expect("failed to write config");
+
+        let mut cmd = Command::cargo_bin("buckets").expect("failed to run command");
+        cmd.current_dir(&repo_dir)
+            .arg("status")
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("No PostgreSQL connection"));
+    }
+
+    #[test]
+    #[serial]
+    fn bootstrap_reports_invalid_credentials() {
+        let temp_dir = get_test_dir();
+        let repo_dir = temp_dir.join(format!("bootstrap_invalid_{}", Uuid::new_v4().simple()));
+        let buckets_dir = repo_dir.join(".buckets");
+        fs::create_dir_all(&buckets_dir).expect("failed to create .buckets");
+        fs::write(buckets_dir.join("database_type"), "PostgreSQL")
+            .expect("failed to write database_type");
+
+        let Some(database) = test_database_or_skip() else {
+            return;
+        };
+        let connection = database
+            .connection_string()
+            .replace("password", "wrong-password");
+
+        fs::write(
+            buckets_dir.join("config"),
+            format!(
+                "ntp_server = \"pool.ntp.org\"\nip_check = \"8.8.8.8\"\nurl_check = \"api.ipify.org\"\npostgresql_connection = \"{}\"\n",
+                connection
+            ),
+        )
+        .expect("failed to write config");
+
+        let previous_database_url = std::env::var("DATABASE_URL").ok();
+        std::env::remove_var("DATABASE_URL");
+
+        let mut cmd = Command::cargo_bin("buckets").expect("failed to run command");
+        cmd.current_dir(&repo_dir)
+            .arg("status")
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("Failed to initialize PostgreSQL"));
+
+        drop(database);
+        restore_database_url(previous_database_url);
+    }
+
+    fn repo_fixture_or_skip() -> Option<RepoFixture> {
+        match panic::catch_unwind(|| RepoFixture::new()) {
+            Ok(Ok(fixture)) => Some(fixture),
+            Ok(Err(message)) => {
+                eprintln!("Skipping bootstrap success test: {message}");
+                None
+            }
+            Err(_) => {
+                eprintln!("Skipping bootstrap success test: Docker is unavailable");
+                None
+            }
+        }
+    }
+
+    fn test_database_or_skip() -> Option<TestDatabase> {
+        match panic::catch_unwind(|| TestDatabase::new()) {
+            Ok(Ok(db)) => Some(db),
+            Ok(Err(message)) => {
+                eprintln!("Skipping bootstrap invalid credential test: {message}");
+                None
+            }
+            Err(_) => {
+                eprintln!("Skipping bootstrap invalid credential test: Docker is unavailable");
+                None
+            }
+        }
+    }
+
+    fn restore_database_url(previous: Option<String>) {
+        if let Some(value) = previous {
+            std::env::set_var("DATABASE_URL", value);
+        } else {
+            std::env::remove_var("DATABASE_URL");
+        }
+    }
+}

--- a/tests/test_cli_bootstrap.rs
+++ b/tests/test_cli_bootstrap.rs
@@ -46,8 +46,7 @@ mod tests {
             fs::File::create(buckets_dir.join("config")).expect("failed to create config file");
         writeln!(
             config_file,
-            "ntp_server = \"pool.ntp.org\"\nip_check = \"8.8.8.8\"\nurl_check = \"api.ipify.org\""
-        )
+            r#"ntp_server = "pool.ntp.org"
         .expect("failed to write config");
 
         let mut cmd = Command::cargo_bin("buckets").expect("failed to run command");

--- a/tests/test_cli_setup.rs
+++ b/tests/test_cli_setup.rs
@@ -1,0 +1,74 @@
+mod common;
+#[cfg(test)]
+mod tests {
+    use assert_cmd::Command;
+    use predicates::prelude::*;
+    use serial_test::serial;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    #[serial]
+    fn test_cli_setup_json_outputs_default_config() {
+        let temp_home = tempdir().expect("failed to create temp home");
+
+        let mut cmd = Command::cargo_bin("buckets").expect("failed to run command");
+        cmd.env("HOME", temp_home.path())
+            .arg("setup")
+            .arg("--json")
+            .assert()
+            .success()
+            .stdout(
+                predicate::str::contains("\"ntp_server\"")
+                    .and(predicate::str::contains("pool.ntp.org"))
+                    .and(predicate::str::contains("\"postgresql_connection\"")),
+            );
+
+        let config_path = temp_home.path().join(".buckets_config.toml");
+        assert!(
+            !config_path.exists(),
+            "json mode should not create config file"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_cli_setup_json_outputs_existing_config() {
+        let temp_home = tempdir().expect("failed to create temp home");
+        let config_path = temp_home.path().join(".buckets_config.toml");
+        let config_content = "ntp_server = \"time.google.com\"\npostgresql_connection = \"postgresql://user:pass@localhost:5432/buckets\"\n";
+        fs::write(&config_path, config_content).expect("failed to write config file");
+
+        let mut cmd = Command::cargo_bin("buckets").expect("failed to run command");
+        cmd.env("HOME", temp_home.path())
+            .arg("setup")
+            .arg("--json")
+            .assert()
+            .success()
+            .stdout(
+                predicate::str::contains("time.google.com")
+                    .and(
+                        predicate::str::contains("postgresql://user:***@localhost:5432/buckets")
+                            .not(),
+                    )
+                    .and(predicate::str::contains(
+                        "postgresql://user:pass@localhost:5432/buckets",
+                    )),
+            );
+    }
+
+    #[test]
+    #[serial]
+    fn test_cli_setup_json_rejects_test_connection() {
+        let temp_home = tempdir().expect("failed to create temp home");
+
+        let mut cmd = Command::cargo_bin("buckets").expect("failed to run command");
+        cmd.env("HOME", temp_home.path())
+            .arg("setup")
+            .arg("--json")
+            .arg("--test-connection")
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("--json cannot be combined"));
+    }
+}

--- a/tests/test_cli_setup.rs
+++ b/tests/test_cli_setup.rs
@@ -36,7 +36,7 @@ mod tests {
     fn test_cli_setup_json_outputs_existing_config() {
         let temp_home = tempdir().expect("failed to create temp home");
         let config_path = temp_home.path().join(".buckets_config.toml");
-        let config_content = "ntp_server = \"time.google.com\"\npostgresql_connection = \"postgresql://user:pass@localhost:5432/buckets\"\n";
+        let config_content = r#"ntp_server = "time.google.com"
         fs::write(&config_path, config_content).expect("failed to write config file");
 
         let mut cmd = Command::cargo_bin("buckets").expect("failed to run command");


### PR DESCRIPTION
## Summary
- introduce a startup bootstrap routine that loads PostgreSQL settings from the repository or global configuration and initializes the shared database manager once per process
- invoke the bootstrap before executing repository-scoped commands so every CLI invocation has the database ready without rerunning `buckets init`
- cover bootstrap success, missing configuration, and invalid credential scenarios with new CLI regression tests that gracefully skip when Docker is unavailable

## Testing
- `cargo test bootstrap_uses_repository_configuration -- --nocapture`
- `cargo test bootstrap_errors_when_connection_missing -- --nocapture`
- `cargo test bootstrap_reports_invalid_credentials -- --nocapture`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911bfa502e88333b24165a4020ea8fb)